### PR TITLE
add user-env-compile documentation to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ OAuth][github-builds] and [Github OAuth — Non-web Application Flow][github-oau
 
 [github-builds]: https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth
 
+Requirements
+------------
+
+The app must have `user-env-compile` enabled for the buildpack to have access to config vars when building.
+
+    heroku labs:enable user-env-compile -a myapp
+
+[Read more aobut user-env-compile.](https://devcenter.heroku.com/articles/labs-user-env-compile)
+
 Usage
 -----
 


### PR DESCRIPTION
I tried out this repo and my `GITHUB_AUTH_TOKEN` config var wasn't being seen by the buildpack.

Turns out, a Heroku Labs feature called [user-env-compile](https://devcenter.heroku.com/articles/labs-user-env-compile) needs to be enabled in order for this to work.
