### PR TITLE
Updates netrc

### DIFF
--- a/support/netrc
+++ b/support/netrc
@@ -1,1 +1,3 @@
-machine github.com login <%= github_token %> password x-oauth-basic
+machine github.com
+login <%= github_token %>
+password x-oauth-basic


### PR DESCRIPTION
This buildpack was recommended to me by Heroku Support, but it's not working. After some digging, it appears that these entries being on a single line is the issue. According to Heroku Support,  .netrc parsing is very rudimentary, and requires them to be on their own lines.